### PR TITLE
진행상황 정리

### DIFF
--- a/src/main/java/koreatech/cse/service/TranslateService.java
+++ b/src/main/java/koreatech/cse/service/TranslateService.java
@@ -1,5 +1,6 @@
 package koreatech.cse.service;
 
+import com.sun.org.apache.xpath.internal.SourceTree;
 import koreatech.cse.domain.Translate;
 import koreatech.cse.repository.TranslateMapper;
 import org.springframework.stereotype.Service;
@@ -17,8 +18,20 @@ public class TranslateService {
         if(trans.getOriginal() == null || trans.getSource()==  null || trans.getTranslated()==  null || trans.getTarget()==  null)
             return false;
 
-        translateMapper.insert(trans);
-        System.out.println("Translate registered : " + new Date() + " | " + trans.getOriginal() + " |");
+        Translate result = translateMapper.searchByOrigTrans(trans);
+
+        if(result != null)
+        {
+            trans.setFavorite(result.getFavorite() + 1);
+            trans.setId(result.getId());
+            translateMapper.updateCount(trans);
+            System.out.println("Translate registered : " + new Date() + " | " + trans.getOriginal() + " | count : " + trans.getFavorite());
+        }
+        else
+        {
+            translateMapper.insert(trans);
+            System.out.println("Translate registered : " + new Date() + " | " + trans.getOriginal() + " |");
+        }
         return true;
     }
 }

--- a/src/main/webapp/WEB-INF/resources/js/googleAPI.js
+++ b/src/main/webapp/WEB-INF/resources/js/googleAPI.js
@@ -61,6 +61,9 @@ recognition.onresult = function(event) {
     final_span.innerHTML = linebreak(finalTranscript);
     interim_span.innerHTML = linebreak(interimTranscript);
 
+    if(location.href.indexOf("/translate/register") != -1) {
+        for_translate.value = linebreak(finalTranscript);
+    }
     console.log('finalTranscript', finalTranscript);
     console.log('interimTranscript', interimTranscript);
     fireCommand(interimTranscript);

--- a/src/main/webapp/WEB-INF/views/translate/list.jsp
+++ b/src/main/webapp/WEB-INF/views/translate/list.jsp
@@ -50,6 +50,7 @@
           <span class="title"></span><p class='txt'>#날짜 : ${u.date}</p>
           <span class="title"></span><p class='txt'>#원문 : ${u.original}</p>
           <span class="title"></span><p class='txt'>#번역결과 : ${u.translated}</p>
+          <span class="title"></span><p class='txt'>#번역 횟수 : ${u.favorite}</p>
 
         </li>
       </ul>

--- a/src/main/webapp/WEB-INF/views/translate/register.jsp
+++ b/src/main/webapp/WEB-INF/views/translate/register.jsp
@@ -45,9 +45,13 @@
       </div>
     </nav>
     <form:form modelAttribute="Translate">
-      Source: <form:input path="source"/><br/>
-      Target: <form:input path="target"/><br/>
-      Voice Recording:<br/>
+      Source:<br><br>
+      <form:radiobutton path="source" value="ko" label ="한국어"/>&ensp;
+      <form:radiobutton path="source" value="en" label ="영어"/>&ensp;<br><br>
+      Target:<br><br>
+      <form:radiobutton path="target" value="ko" label ="한국어"/>&ensp;
+      <form:radiobutton path="target" value="en" label ="영어"/>&ensp;<br><br>
+      Voice Recording:<br><br/>
 
 
       <div id="result">
@@ -57,17 +61,17 @@
         <form:input type="hidden" path="original" id="for_translate" class="final" value="" />
       </div>
 
-      <div class="fixed-action-btn" style="bottom: 35px; right: 230px;">
-        <a id="test" class="btn-floating btn-large waves-effect waves-light blue" onclick="start();"><i class="material-icons">mic</i></a>
+      <div class="fixed-action-btn" style="position: relative; top: 1px; left: 24px;">
+        <button class="btn waves-effect waves-center" type="submit" value="Register" id="trans_submit" style="font-size: 20pt"
+                onClick="alertStr('번역 완료!') ">Register
+          <i class="material-icons center">check_box</i>
+        </button>
+      </div>
+      <div class="fixed-action-btn" style="position: relative; bottom: 51px; left: 236px">
+        <a class="btn-floating btn-large waves-effect waves-light blue" style="height: 37px; width: 37px; padding: 2px; border-radius: 3px" onclick="start();" >
+          <img class="translation-icon" src="/resources/mic.png" width="32" height="34"></a>
       </div>
 
-      <div class="fixed-action-btn" style="bottom: 35px; right: 170px;">
-
-        <a id="btn-mic2" class="btn-floating btn-large waves-effect waves-light red" onclick="save_data(document.getElementById('final_span').innerHTML);
-                                                                                                      Materialize.toast('SUBMIT', 1000);
-                                                                                                      "><i class="material-icons">stop</i></a>
-      </div>
-      <input type="submit" value="Register" id="trans_submit" onclick="alertStr('번역 완료!')"/><i class="material-icons"></i>
 
     </form:form>
   </div>

--- a/src/main/webapp/WEB-INF/views/translate/register.jsp
+++ b/src/main/webapp/WEB-INF/views/translate/register.jsp
@@ -52,22 +52,22 @@
 
       <div id="result">
 
-        <span style="display:none;" class="final" id="final_span"></span>
+        <span class="final" id="final_span"></span>
         <span class="interim" id="interim_span"></span>
-        <form:input  path="original" id="for_translate" class="final" value="" />
+        <form:input type="hidden" path="original" id="for_translate" class="final" value="" />
       </div>
 
-      <div class="fixed-action-btn" style="position: relative; top: 1px; left: 24px;">
-        <button class="btn waves-effect waves-center" type="submit" value="Register" id="trans_submit" style="font-size: 20pt"
-                onClick="alertStr('번역 완료!') ">Register
-          <i class="material-icons center">check_box</i>
-        </button>
-      </div>
-      <div class="fixed-action-btn" style="position: relative; bottom: 51px; left: 236px">
-        <a class="btn-floating btn-large waves-effect waves-light blue" style="height: 37px; width: 37px; padding: 2px; border-radius: 3px" onclick="start();" >
-          <img class="translation-icon" src="/resources/mic.png" width="32" height="34"></a>
+      <div class="fixed-action-btn" style="bottom: 35px; right: 230px;">
+        <a id="test" class="btn-floating btn-large waves-effect waves-light blue" onclick="start();"><i class="material-icons">mic</i></a>
       </div>
 
+      <div class="fixed-action-btn" style="bottom: 35px; right: 170px;">
+
+        <a id="btn-mic2" class="btn-floating btn-large waves-effect waves-light red" onclick="save_data(document.getElementById('final_span').innerHTML);
+                                                                                                      Materialize.toast('SUBMIT', 1000);
+                                                                                                      "><i class="material-icons">stop</i></a>
+      </div>
+      <input type="submit" value="Register" id="trans_submit" onclick="alertStr('번역 완료!')"/><i class="material-icons"></i>
 
     </form:form>
   </div>


### PR DESCRIPTION
횟수 순서 출력 적용완료

TranslateService : 등록 시 기등록된 번역인 경우 횟수 추가하도록 추가
list : 횟수 추가. 일단 테스트로 넣은 기능이라 나중에 뺄지 말지는 협의사항
register : 데이터 추가를 위해 넣었던 for_translation 추가, 사용하지 않던 save_data가 아직 남아있던 구문 삭제, 언어 입력을 타이핑에서 radiobutton으로 변경
googleAPI : register 외의 타 페이지에선 동작하지 않도록 조건문 추가

